### PR TITLE
feat: cast frames to precision before fwd instead of dataloader

### DIFF
--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -77,6 +77,7 @@ args = tyro.cli(Args)
 
 def dynamics_loss_fn(params, state, inputs):
     """Compute masked dynamics loss"""
+    inputs["videos"] = inputs["videos"].astype(jnp.float32) / 255.0
     outputs = state.apply_fn(
         params,
         inputs,

--- a/train_lam.py
+++ b/train_lam.py
@@ -67,6 +67,7 @@ args = tyro.cli(Args)
 
 def lam_loss_fn(params, state, inputs):
     # --- Compute loss ---
+    inputs["videos"] = inputs["videos"].astype(jnp.float32) / 255.0
     outputs = state.apply_fn(
         params, inputs, training=True, rngs={"dropout": inputs["rng"]}
     )

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -67,6 +67,7 @@ args = tyro.cli(Args)
 
 def tokenizer_loss_fn(params, state, inputs):
     # --- Compute loss ---
+    inputs["videos"] = inputs["videos"].astype(jnp.float32) / 255.0
     outputs = state.apply_fn(
         params,
         inputs,

--- a/utils/dataloader.py
+++ b/utils/dataloader.py
@@ -89,9 +89,7 @@ class ProcessEpisodeAndSlice(grain.transforms.RandomMap):
 
         seq = episode_tensor[start_idx : start_idx + self.seq_len]
 
-        processed_sequence = seq.astype(np.float32) / 255.0
-
-        return processed_sequence
+        return seq
 
 
 def get_dataloader(


### PR DESCRIPTION
- We now cast to full precision right before the forward pass rather than in the dataloader
- Thus, we now use less bandwidth during dataloading & less memory bandwidth between host and accelerator