### PR TITLE
fix: cast video to jnp.array before dtype casting

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
     )
     dataloader = iter(dataloader)
     video_batch = next(dataloader)
-    video_batch = video_batch.astype(args.dtype) / 255.0
+    video_batch = jnp.asarray(video_batch).astype(args.dtype) / 255.0
     # Get latent actions for all videos in the batch
     batch = dict(videos=video_batch)
     action_batch = genie.vq_encode(batch, training=False)


### PR DESCRIPTION
- numpy promotes bf16 to fp32 on python division, hence the video input into the model was fp32 during sampling (while being bf16 (/dtype) during training)
- casting to `jax.Array` fixes this, since the JAX promotion semantics (https://docs.jax.dev/en/latest/type_promotion.html) adhere to the dtype