### PR TITLE
feat: donate optimizer buffer during nnx.jit

### DIFF
--- a/train_dynamics.py
+++ b/train_dynamics.py
@@ -384,7 +384,7 @@ def main(args: Args) -> None:
         )
         return ce_loss, (outputs["recon"], metrics)
 
-    @nnx.jit
+    @nnx.jit(donate_argnums=0)
     def train_step(
         optimizer: nnx.Optimizer, inputs: dict
     ) -> tuple[jax.Array, jax.Array, dict]:

--- a/train_lam.py
+++ b/train_lam.py
@@ -342,7 +342,7 @@ def main(args: Args) -> None:
         )
         return loss, (outputs["recon"], index_counts, metrics)
 
-    @nnx.jit
+    @nnx.jit(donate_argnums=0)
     def train_step(
         optimizer: nnx.Optimizer,
         inputs: dict,

--- a/train_tokenizer.py
+++ b/train_tokenizer.py
@@ -334,7 +334,7 @@ def main(args: Args) -> None:
         )
         return loss, (outputs["recon"], metrics)
 
-    @nnx.jit
+    @nnx.jit(donate_argnums=0)
     def train_step(
         optimizer: nnx.Optimizer, inputs: dict
     ) -> tuple[jax.Array, jax.Array, dict]:


### PR DESCRIPTION
Tokenizer:
`Total memory size: 9.1 GB` -> `Total memory size: 8.8 GB`

LAM:
`Total memory size: 1.5 GB` -> `Total memory size: 1.1 GB`

Dynamics:
`Total memory size: 10.6 GB` -> `Total memory size: 9.7 GB`

This is using the default args.