### PR TITLE
feat: Top-k-accuracy calculation

### DIFF
--- a/jasmine/train_dynamics.py
+++ b/jasmine/train_dynamics.py
@@ -331,7 +331,7 @@ def _calculate_top_k_accuracy(
     mask: jax.Array,
     k: int,
 ) -> jax.Array:
-    topk_indices = jnp.argsort(token_logits, axis=-1)[..., -k:]
+    topk_indices = jax.lax.top_k(token_logits, k)[1]
     topk_correct = jnp.any(topk_indices == video_tokens[..., None], axis=-1)
     topk_acc = (mask * topk_correct).sum() / mask.sum()
     return topk_acc

--- a/jasmine/train_dynamics.py
+++ b/jasmine/train_dynamics.py
@@ -330,7 +330,7 @@ def _calculate_top_k_accuracy(
     video_tokens: jax.Array,
     mask: jax.Array,
     k: int,
-) -> tuple[jax.Array, jax.Array]:
+) -> jax.Array:
     topk_indices = jnp.argsort(token_logits, axis=-1)[..., -k:]
     topk_correct = jnp.any(topk_indices == video_tokens[..., None], axis=-1)
     topk_acc = (mask * topk_correct).sum() / mask.sum()

--- a/jasmine/train_dynamics.py
+++ b/jasmine/train_dynamics.py
@@ -325,7 +325,7 @@ def restore_or_initialize_components(
     return step, optimizer, train_iterator, val_iterator, rng
 
 
-def calculate_topk_accuracy(
+def _calculate_top_k_accuracy(
     token_logits: jax.Array,
     video_tokens: jax.Array,
     mask: jax.Array,
@@ -350,16 +350,16 @@ def _calculate_step_metrics(
     )
     ce_loss = (mask * ce_loss).sum() / mask.sum()
 
-    top_1_acc = calculate_topk_accuracy(
+    masked_token_top_1_acc = _calculate_top_k_accuracy(
         outputs["token_logits"], outputs["video_tokens"], mask, 1
     )
-    top_2_acc = calculate_topk_accuracy(
+    masked_token_top_2_acc = _calculate_top_k_accuracy(
         outputs["token_logits"], outputs["video_tokens"], mask, 2
     )
-    top_5_acc = calculate_topk_accuracy(
+    masked_token_top_5_acc = _calculate_top_k_accuracy(
         outputs["token_logits"], outputs["video_tokens"], mask, 5
     )
-    top_16_acc = calculate_topk_accuracy(
+    masked_token_top_16_acc = _calculate_top_k_accuracy(
         outputs["token_logits"], outputs["video_tokens"], mask, 16
     )
 
@@ -376,10 +376,10 @@ def _calculate_step_metrics(
     codebook_usage_tokenizer = (index_counts_tokenizer != 0).mean()
     metrics = dict(
         cross_entropy_loss=ce_loss,
-        masked_token_top1_accuracy=top_1_acc,
-        masked_token_top2_accuracy=top_2_acc,
-        masked_token_top5_accuracy=top_5_acc,
-        masked_token_top16_accuracy=top_16_acc,
+        masked_token_top1_accuracy=masked_token_top_1_acc,
+        masked_token_top2_accuracy=masked_token_top_2_acc,
+        masked_token_top5_accuracy=masked_token_top_5_acc,
+        masked_token_top16_accuracy=masked_token_top_16_acc,
         select_logit=outputs["token_logits"].max(-1).mean(),
         select_p=select_probs.max(-1).mean(),
         entropy=jax.scipy.special.entr(select_probs).sum(-1).mean(),

--- a/jasmine/train_dynamics.py
+++ b/jasmine/train_dynamics.py
@@ -326,13 +326,15 @@ def restore_or_initialize_components(
 
 
 def _calculate_top_k_accuracy(
-    token_logits: jax.Array,
-    video_tokens: jax.Array,
+    token_logits_BTNV: jax.Array,
+    video_tokens_BTN: jax.Array,
     mask: jax.Array,
     k: int,
 ) -> jax.Array:
-    _, topk_indices = jax.lax.top_k(token_logits, k)
-    topk_correct = jnp.any(topk_indices == video_tokens[..., None], axis=-1)
+    _, topk_indices_BTNK = jax.lax.top_k(token_logits_BTNV, k)
+    topk_correct = jnp.any(
+        topk_indices_BTNK == video_tokens_BTN[..., jnp.newaxis], axis=-1
+    )
     topk_acc = (mask * topk_correct).sum() / mask.sum()
     return topk_acc
 

--- a/jasmine/train_dynamics.py
+++ b/jasmine/train_dynamics.py
@@ -331,7 +331,7 @@ def _calculate_top_k_accuracy(
     mask: jax.Array,
     k: int,
 ) -> jax.Array:
-    topk_indices = jax.lax.top_k(token_logits, k)[1]
+    _, topk_indices = jax.lax.top_k(token_logits, k)
     topk_correct = jnp.any(topk_indices == video_tokens[..., None], axis=-1)
     topk_acc = (mask * topk_correct).sum() / mask.sum()
     return topk_acc

--- a/jasmine/train_dynamics.py
+++ b/jasmine/train_dynamics.py
@@ -328,14 +328,14 @@ def restore_or_initialize_components(
 def _calculate_top_k_accuracy(
     token_logits_BTNV: jax.Array,
     video_tokens_BTN: jax.Array,
-    mask: jax.Array,
+    mask_BTN: jax.Array,
     k: int,
 ) -> jax.Array:
     _, topk_indices_BTNK = jax.lax.top_k(token_logits_BTNV, k)
     topk_correct = jnp.any(
         topk_indices_BTNK == video_tokens_BTN[..., jnp.newaxis], axis=-1
     )
-    topk_acc = (mask * topk_correct).sum() / mask.sum()
+    topk_acc = (mask_BTN * topk_correct).sum() / mask_BTN.sum()
     return topk_acc
 
 
@@ -345,24 +345,24 @@ def _calculate_step_metrics(
     num_actions: int,
     num_patch_latents: int,
 ) -> tuple[jax.Array, dict]:
-    mask = outputs["mask"]
+    mask_BTN = outputs["mask"]
     outputs["token_logits"] = outputs["token_logits"].astype(jnp.float32)
     ce_loss = optax.softmax_cross_entropy_with_integer_labels(
         outputs["token_logits"], outputs["video_tokens"]
     )
-    ce_loss = (mask * ce_loss).sum() / mask.sum()
+    ce_loss = (mask_BTN * ce_loss).sum() / mask_BTN.sum()
 
     masked_token_top_1_acc = _calculate_top_k_accuracy(
-        outputs["token_logits"], outputs["video_tokens"], mask, 1
+        outputs["token_logits"], outputs["video_tokens"], mask_BTN, 1
     )
     masked_token_top_2_acc = _calculate_top_k_accuracy(
-        outputs["token_logits"], outputs["video_tokens"], mask, 2
+        outputs["token_logits"], outputs["video_tokens"], mask_BTN, 2
     )
     masked_token_top_5_acc = _calculate_top_k_accuracy(
-        outputs["token_logits"], outputs["video_tokens"], mask, 5
+        outputs["token_logits"], outputs["video_tokens"], mask_BTN, 5
     )
     masked_token_top_16_acc = _calculate_top_k_accuracy(
-        outputs["token_logits"], outputs["video_tokens"], mask, 16
+        outputs["token_logits"], outputs["video_tokens"], mask_BTN, 16
     )
 
     select_probs = jax.nn.softmax(outputs["token_logits"])


### PR DESCRIPTION
Added top-k-accuracy measure (same as in Table 1. of the jafar paper)

Example [here](https://wandb.ai/instant-uv/jafar/runs/29483/workspace/panel/cudo4xy2d?nw=nwuseravocadoali)

<img width="1381" height="1338" alt="image" src="https://github.com/user-attachments/assets/d288e826-e3dc-4092-99ee-62d5253c7b7a" />

